### PR TITLE
TR-3375: cleanup localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.xcuserstate
 *.xcbkptlist
 *.xcodeproj/xcuserdata
+tmp/

--- a/DateRangePicker/de.lproj/ExpandedDateRangePickerController.strings
+++ b/DateRangePicker/de.lproj/ExpandedDateRangePickerController.strings
@@ -1,3 +1,2 @@
-
 /* Class = "NSTextFieldCell"; title = "Date Range:"; ObjectID = "OQ9-0t-PIG"; */
 "OQ9-0t-PIG.title" = "Datumsbereich:";

--- a/DateRangePicker/de.lproj/Localizable.strings
+++ b/DateRangePicker/de.lproj/Localizable.strings
@@ -1,18 +1,53 @@
-"Custom" = "Eigener";
-"Past %d Days" = "Letzten %d Tage";
-"%d Days" = "%d Tage";
-"Yesterday" = "Gestern";
-"Last Week" = "Letzte Woche";
-"Last Month" = "Letzter Monat";
-"Last Quarter" = "Letztes Quartal";
-"Last Year" = "Letztes Jahr";
-"Today" = "Heute";
-"This Week" = "Diese Woche";
-"This Month" = "Dieser Monat";
-"This Quarter" = "Dieses Quartal";
-"This Year" = "Dieses Jahr";
-"Week" = "Woche";
-"Month" = "Monat";
-"Quarter" = "Quartal";
-"Year" = "Jahr";
+/* Customization label for the Date Range picker. */
 "Date Range" = "Datumsbereich";
+
+/* Date Range short title for this month. */
+"Month" = "Monat";
+
+/* Date Range short title for this quarter. */
+"Quarter" = "Quartal";
+
+/* Date Range short title for this week. */
+"Week" = "Woche";
+
+/* Date Range short title for this year. */
+"Year" = "Jahr";
+
+/* Date Range title for last month. */
+"Last Month" = "Letzter Monat";
+
+/* Date Range title for last quarter. */
+"Last Quarter" = "Letztes Quartal";
+
+/* Date Range title for last week. */
+"Last Week" = "Letzte Woche";
+
+/* Date Range title for last year. */
+"Last Year" = "Letztes Jahr";
+
+/* Date Range title for the current day. */
+"Today" = "Heute";
+
+/* Date Range title for the previous day. */
+"Yesterday" = "Gestern";
+
+/* Date Range title for this month. */
+"This Month" = "Dieser Monat";
+
+/* Date Range title for this quarter. */
+"This Quarter" = "Dieses Quartal";
+
+/* Date Range title for this week. */
+"This Week" = "Diese Woche";
+
+/* Date Range title for this year. */
+"This Year" = "Dieses Jahr";
+
+/* Shorthand title for a date range spanning the past %d days. */
+"%d Days" = "%d Tage";
+
+/* Title for a custom date range. */
+"Custom" = "Eigener";
+
+/* Title for a date range spanning the past %d days. */
+"Past %d Days" = "Letzten %d Tage";

--- a/DateRangePicker/ru.lproj/ExpandedDateRangePickerController.strings
+++ b/DateRangePicker/ru.lproj/ExpandedDateRangePickerController.strings
@@ -1,3 +1,2 @@
-
 /* Class = "NSTextFieldCell"; title = "Date Range:"; ObjectID = "OQ9-0t-PIG"; */
 "OQ9-0t-PIG.title" = "Временной интервал:";

--- a/DateRangePicker/ru.lproj/Localizable.strings
+++ b/DateRangePicker/ru.lproj/Localizable.strings
@@ -1,14 +1,41 @@
-"Custom" = " Произвольный";
-"Past %d Days" = "%d д. назад";
-"%d Days" = "%d д.";
-"Yesterday" = "Вчера";
-"Today" = "Сегодня";
-"This Week" = "Эта неделя";
-"This Month" = "Этот месяц";
-"This Quarter" = "Этот квартал";
-"This Year" = "Этот год";
-"Week" = "Неделя";
-"Month" = "Месяц";
-"Quarter" = "Квартал";
-"Year" = "Год";
+/* Customization label for the Date Range picker. */
 "Date Range" = "Временной интервал";
+
+/* Date Range short title for this month. */
+"Month" = "Месяц";
+
+/* Date Range short title for this quarter. */
+"Quarter" = "Квартал";
+
+/* Date Range short title for this week. */
+"Week" = "Неделя";
+
+/* Date Range short title for this year. */
+"Year" = "Год";
+
+/* Date Range title for the current day. */
+"Today" = "Сегодня";
+
+/* Date Range title for the previous day. */
+"Yesterday" = "Вчера";
+
+/* Date Range title for this month. */
+"This Month" = "Этот месяц";
+
+/* Date Range title for this quarter. */
+"This Quarter" = "Этот квартал";
+
+/* Date Range title for this week. */
+"This Week" = "Эта неделя";
+
+/* Date Range title for this year. */
+"This Year" = "Этот год";
+
+/* Shorthand title for a date range spanning the past %d days. */
+"%d Days" = "%d д.";
+
+/* Title for a custom date range. */
+"Custom" = " Произвольный";
+
+/* Title for a date range spanning the past %d days. */
+"Past %d Days" = "%d д. назад";

--- a/DateRangePicker/zh-Hans.lproj/ExpandedDateRangePickerController.strings
+++ b/DateRangePicker/zh-Hans.lproj/ExpandedDateRangePickerController.strings
@@ -1,3 +1,2 @@
 /* Class = "NSTextFieldCell"; title = "Date Range:"; ObjectID = "OQ9-0t-PIG"; */
 "OQ9-0t-PIG.title" = "日期区间：";
-

--- a/DateRangePicker/zh-Hans.lproj/Localizable.strings
+++ b/DateRangePicker/zh-Hans.lproj/Localizable.strings
@@ -1,11 +1,17 @@
-/* Shorthand title for a date range spanning the past %d days. */
-"%d Days" = "%d 天";
-
-/* Title for a custom date range. */
-"Custom" = "自定义";
-
 /* Customization label for the Date Range picker. */
 "Date Range" = "日期区间";
+
+/* Date Range short title for this month. */
+"Month" = "月";
+
+/* Date Range short title for this quarter. */
+"Quarter" = "季度";
+
+/* Date Range short title for this week. */
+"Week" = "周";
+
+/* Date Range short title for this year. */
+"Year" = "年";
 
 /* Date Range title for last month. */
 "Last Month" = "上个月";
@@ -19,14 +25,11 @@
 /* Date Range title for last year. */
 "Last Year" = "去年";
 
-/* Date Range short title for this month. */
-"Month" = "月";
+/* Date Range title for the current day. */
+"Today" = "今天";
 
-/* Title for a date range spanning the past %d days. */
-"Past %d Days" = "过去 %d 天";
-
-/* Date Range short title for this quarter. */
-"Quarter" = "季度";
+/* Date Range title for the previous day. */
+"Yesterday" = "昨天";
 
 /* Date Range title for this month. */
 "This Month" = "本月";
@@ -40,15 +43,11 @@
 /* Date Range title for this year. */
 "This Year" = "今年";
 
-/* Date Range title for the current day. */
-"Today" = "今天";
+/* Shorthand title for a date range spanning the past %d days. */
+"%d Days" = "%d 天";
 
-/* Date Range short title for this week. */
-"Week" = "周";
+/* Title for a custom date range. */
+"Custom" = "自定义";
 
-/* Date Range short title for this year. */
-"Year" = "年";
-
-/* Date Range title for the previous day. */
-"Yesterday" = "昨天";
-
+/* Title for a date range spanning the past %d days. */
+"Past %d Days" = "过去 %d 天";

--- a/localize.sh
+++ b/localize.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+XLIFF_PATH=./tmp/xcode-xliff-export
+
+function export_xliff {
+  xcodebuild -exportLocalizations \
+      -project DateRangePicker.xcodeproj \
+      -localizationPath $XLIFF_PATH \
+      -exportLanguage en \
+      -exportLanguage de \
+      -exportLanguage zh-Hans \
+      -exportLanguage ru
+}
+
+function find_strings {
+  # Exclude framework and Xliff output directories
+  find . \
+    -type d \( -path ./tmp -o -path ./Frameworks -o -path ./Pods \) -prune \
+    -o -name \*.strings -print
+}
+
+function import_result {
+  if [ $# -eq 0 ]
+  then
+    print_help
+    exit 1
+  fi
+
+  rsync -av --prune-empty-dirs --include '*/' --include '*.strings' --exclude '*' "$1/" "."
+}
+
+function print_help {
+  echo -e "Usage:\t$0 [command [options ...]]"
+  echo ""
+  echo "Commands:"
+  echo -e "  strings\t\tList all .strings files in the project."
+  echo -e "  xliff\t\t\tExport Xliff for all localizations to ${XLIFF_PATH}"
+  echo -e "  import source_dir\tImports all .strings from source_dir, preserving directory structures"
+}
+
+# No command provided
+if [ $# -eq 0 ]
+then
+  print_help
+  exit 1
+fi
+
+# Execute each command
+case "$1"
+in
+"strings")
+  find_strings
+  ;;
+"xliff")
+  export_xliff
+  ;;
+"import")
+  shift
+  import_result $@
+  ;;
+
+"-h")
+  ;& # fallthrough
+"--help")
+  ;& # fallthrough
+"help")
+  ;& # fallthrough
+*)
+  print_help
+  ;;
+esac


### PR DESCRIPTION
- adds a `localize.sh` script to simplify the export and import process
- reorders all `.strings` files from the framework in a stable sort order by Nib widget title, comment, or ID

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrmage/daterangepicker/16)
<!-- Reviewable:end -->
